### PR TITLE
Add .gitattributes to normalize line-endings

### DIFF
--- a/source-control/.gitattributes
+++ b/source-control/.gitattributes
@@ -1,0 +1,18 @@
+# Automatically normalize line endings for all text-based files
+# http://git-scm.com/docs/gitattributes#_end_of_line_conversion
+* text=auto
+
+# For the following file types, normalize line endings to LF on
+# checkin and prevent conversion to CRLF when they are checked out
+# (this is required in order to prevent newline related issues like,
+# for example, after the build script is run)
+.*      text eol=lf
+*.css   text eol=lf
+*.html  text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.sass  text eol=lf
+*.md    text eol=lf
+*.sh    text eol=lf
+*.txt   text eol=lf
+*.xml   text eol=lf


### PR DESCRIPTION
#### Reviewer Notes
- @tborres : Please take a look when you get a chance (no hurry).
#### Changes in this PR
- Added `.gitattributes` file to normalize line-endings to `lf`. This prevents a number of issues we've seen in the past.
